### PR TITLE
Fix 'release' step of publish workflow

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -21,8 +21,8 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         with:
-          tag_name : ${{ steps.changelog_reader.outputs.current-version}}
-          release_name: ${{ steps.changelog_reader.outputs.current-version}}
+          tag_name : ${{ steps.changelog_reader.outputs.version}}
+          release_name: ${{ steps.changelog_reader.outputs.version}}
           body: Publish ${{ steps.changelog_reader.outputs.changes }}
   publish:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v2
       - name: Get Changelog Entry

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -8,7 +8,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Get Changelog Entry

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -5,7 +5,25 @@ permissions:
       id-token: write
       contents: read
 
-jobs: 
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          path: ./CHANGELOG.md
+      - name: Create a Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name : ${{ steps.changelog_reader.outputs.current-version}}
+          release_name: ${{ steps.changelog_reader.outputs.current-version}}
+          body: Publish ${{ steps.changelog_reader.outputs.changes }}
   publish:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -34,15 +52,6 @@ jobs:
         run: |
            echo "Version: ${{ steps.changelog_reader.outputs.version }}"
            echo "Changes: ${{ steps.changelog_reader.outputs.changes }}"
-      - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        with:
-          tag_name : ${{ steps.package_version.outputs.current-version}}
-          release_name: ${{ steps.package_version.outputs.current-version}}
-          body: Publish ${{ steps.changelog_reader.outputs.changes }}
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:


### PR DESCRIPTION
This is moved out of the existing job, because that runs in a matrix and so will run for every OS (which we don't want - it should run once per workflow run).

It also fixes the changelog reader output variable names, and adds the permission required for the job to write to the repo.